### PR TITLE
DBAAS-1403 Add ReadOnly registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ bin/*
 # Editor/IDE specific files.
 *.sublime-project
 *.sublime-workspace
+
+.idea/
+Dockerfile.packed
+update_manifest.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DOCKER_BUILDTAGS include_oss include_gcs
 WORKDIR $DISTRIBUTION_DIR
 COPY . $DISTRIBUTION_DIR
 COPY cmd/registry/config-dev.yml /etc/docker/registry/config.yml
+COPY cmd/registry/config-read-only.yml /etc/docker/registry/config-read-only.yml
 
 RUN set -ex \
     && apk add --no-cache make git

--- a/Makefile.distribution
+++ b/Makefile.distribution
@@ -1,5 +1,5 @@
-all: build/rpms/strato-registry-1-0.x86_64.rpm
-	docker build .
+all: build/rpms/strato-registry-1-0.x86_64.rpm build/rpms/strato-registry-readonly-1-0.x86_64.rpm
+	skipper build registry
 
 ifeq ($(V),1)
     Q =
@@ -10,7 +10,7 @@ else
 endif
 
 STRATO_REGISTRY_RPMBUILD_ROOT = $(PWD)/build/rpmbuild
-build/rpms/strato-registry-1-0.x86_64.rpm:
+build/rpms/strato-registry-1-0.x86_64.rpm: $(shell find strato-docker-registry/)
 	@echo "RPM      " $@
 	-mkdir -p $(@D)
 	mkdir -p $(STRATO_REGISTRY_RPMBUILD_ROOT)
@@ -18,5 +18,20 @@ build/rpms/strato-registry-1-0.x86_64.rpm:
 	$(Q)cp $(STRATO_REGISTRY_RPMBUILD_ROOT)/RPMS/x86_64/strato-registry*.x86_64.rpm $@
 	$(Q)rm -rf $(STRATO_REGISTRY_RPMBUILD_ROOT)
 
+build/rpms/strato-registry-readonly-1-0.x86_64.rpm: $(shell find strato-docker-registry-readonly/)
+	@echo "RPM      " $@
+	-mkdir -p $(@D)
+	mkdir -p $(STRATO_REGISTRY_RPMBUILD_ROOT)
+	$(Q)TOP=$(PWD) rpmbuild -bb -vv --define "_topdir $(STRATO_REGISTRY_RPMBUILD_ROOT)" strato-docker-registry-readonly/strato-registry-readonly.spec $(SWALLOW_STDOUT)
+	$(Q)cp $(STRATO_REGISTRY_RPMBUILD_ROOT)/RPMS/x86_64/strato-registry-readonly*.x86_64.rpm $@
+	$(Q)rm -rf $(STRATO_REGISTRY_RPMBUILD_ROOT)
+
 clean:
 	$(Q)rm -rf build/
+
+package: all
+	packager pack artifacts.yaml --auto-push
+
+deploy: package
+	python -m packaging_tools.upgrade_manifest_generator artifacts.yaml --dirty
+	upgrade -v $(IP) update_manifest.json

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -5,4 +5,11 @@ services:
     docker-registry:
         image_name: registry
         rpms:
-        - build/rpms
+        - build/rpms/strato-registry-1-0.x86_64.rpm
+
+    docker-registry-readonly:
+        image_name: registry
+        rpms:
+        - build/rpms/strato-registry-readonly-1-0.x86_64.rpm
+
+rpms_dir: build/rpms

--- a/cmd/registry/config-read-only.yml
+++ b/cmd/registry/config-read-only.yml
@@ -1,0 +1,26 @@
+version: 0.1
+
+log:
+  level: warn
+  fields:
+    service: registry
+
+storage:
+  maintenance:
+    readonly:
+      enabled: true
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+
+http:
+  addr: :1819
+  headers:
+    X-Content-Type-Options: [nosniff]
+
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -1,6 +1,6 @@
 registry: rackattack-nas.dc1:5000
 build-container-image: dev-base
-build-container-tag: 2f876de89e68858250e00d45985cc23332ac759f
+build-container-tag: bb2b27463e514aa58cbc6722f832ff3bf078c2df
 
 containers:
     registry: Dockerfile

--- a/strato-docker-registry-readonly/docker-registry-readonly.service
+++ b/strato-docker-registry-readonly/docker-registry-readonly.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Docker Registry ReadOnly
+After=docker.service
+
+[Service]
+Type=simple
+ExecStartPre=-/usr/bin/docker-service-stop.sh docker-registry-readonly.yml
+ExecStart=/usr/bin/docker-service-start.sh docker-registry-readonly.yml docker-registry-readonly.log
+ExecStop=/usr/bin/docker-service-stop.sh docker-registry-readonly.yml
+StartLimitInterval=0
+
+[Install]
+WantedBy=multi-user.target

--- a/strato-docker-registry-readonly/docker-registry-readonly.service.clustermanager
+++ b/strato-docker-registry-readonly/docker-registry-readonly.service.clustermanager
@@ -1,0 +1,1 @@
+{"installationType": "controller", "group": "API Services"}

--- a/strato-docker-registry-readonly/docker-registry-readonly.yml
+++ b/strato-docker-registry-readonly/docker-registry-readonly.yml
@@ -1,0 +1,9 @@
+docker-registry-readonly:
+  container_name: docker-registry-readonly.service.strato
+  image: docker-registry.service.strato:1818/registry:latest
+  command: ["serve", "/etc/docker/registry/config-read-only.yml"]
+  labels:
+  - com.example.description=Docker Registry ReadOnly
+  net: host
+  volumes:
+  - /mnt/containers/registry:/var/lib/registry:ro

--- a/strato-docker-registry-readonly/strato-registry-readonly.spec
+++ b/strato-docker-registry-readonly/strato-registry-readonly.spec
@@ -1,0 +1,26 @@
+Name:           strato-registry-readonly
+Version:        1.0
+Release:        1%{?dist}
+License:        Stratoscale
+Summary:        Stratoscale Registry Files
+
+%description
+Files needed for strato's docker registry readonly service.
+
+%build
+cp $TOP/strato-docker-registry-readonly/docker-registry-readonly.service .
+cp $TOP/strato-docker-registry-readonly/docker-registry-readonly.yml .
+cp $TOP/strato-docker-registry-readonly/docker-registry-readonly.service.clustermanager .
+
+%install
+install -d %{buildroot}/etc/stratoscale/compose/rootfs-star/
+install -pm 644 docker-registry-readonly.yml %{buildroot}/etc/stratoscale/compose/rootfs-star/
+install -d %{buildroot}/usr/lib/systemd/system
+install -pm 644 docker-registry-readonly.service %{buildroot}/usr/lib/systemd/system/
+install -d %{buildroot}/etc/stratoscale/clustermanager/services/control/
+install -pm 644 docker-registry-readonly.service.clustermanager %{buildroot}/etc/stratoscale/clustermanager/services/control/docker-registry-readonly.service
+
+%files
+/usr/lib/systemd/system/docker-registry-readonly.service
+/etc/stratoscale/compose/rootfs-star/docker-registry-readonly.yml
+/etc/stratoscale/clustermanager/services/control/docker-registry-readonly.service


### PR DESCRIPTION
This will allow us to expose to services running in VMs the ability to pull services containers from cluster docker registry but without the risk of pushing from the guest network